### PR TITLE
set Mechanism "PLAIN" in Server.saslAuth

### DIFF
--- a/lib/memjs/server.js
+++ b/lib/memjs/server.js
@@ -26,7 +26,7 @@ Server.prototype.listSasl = function() {
 
 Server.prototype.saslAuth = function() {
   var authStr = '\0' + this.username + '\0' + this.password;
-  var buf = makeRequestBuffer(0x21, '', '', authStr);
+  var buf = makeRequestBuffer(0x21, 'PLAIN', '', authStr);
   this.write(buf);
 }
 


### PR DESCRIPTION
Hi Amit.

Thank you for a mail about SASL Auth on Heroku.

I found a bug of SASL Auth and fixed it.

I've read this document (http://code.google.com/p/memcached/wiki/SASLAuthProtocol#Command_Reference)  and I think SASL Auth requires "Mechanism" Key at OpCode 0x21.
Also, Dalli (Ruby's Memcache Client) setting Mechanism Key.
https://github.com/mperham/dalli/blob/9f8196fa60fc53656dd8d59731a7b3fcadcc2bbe/lib/dalli/server.rb#L521

So I added "PLAIN" Mechanism line 29 in server.js, and it works with Heroku's Memcache!!

This is test code.
https://gist.github.com/3113038

```
% cd memjs/
% wget https://raw.github.com/gist/3113038/6dceee38a2b81654bf61ad71e99e51405bcb82ce/memjs_test_heroku.js -O test/memjs_test_heroku.js
% heroku create --stack cedar
% heroku addons:add memcache:5mb
% heroku config --shell

=> get MEMCACHE_PASSWORD, MEMCACHE_SERVERS and MEMCACHE_USERNAME

% export MEMCACHE_SERVERS=mc6.ec2.northscale.net
% export MEMCACHE_PASSWORD=abcdefg
% export MEMCACHE_USERNAME=1234foobar

# run test
% node test/memjs_test_heroku.js
```

I couldn't test Memcachier, because I couldn't connect from my house.
