### PR TITLE
Expiration time results in "Invalid arguments"-error?

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -78,7 +78,7 @@ Client.prototype.get = function(key, callback) {
 // Takes a key and value to put to memcache and a callback. The success of the
 // operation is signaled through the argument to the callback.
 Client.prototype.set = function(key, value, callback) {
-  var extras = '\0\0\0\0' + makeExpiration(this.options.expires);
+  var extras = Buffer.concat([new Buffer('00000000', 'hex'), makeExpiration(this.options.expires)]);
   var request = makeRequestBuffer(1, key, extras, value);
   var serv = this.server(key);
   var logger = this.options.logger;
@@ -102,7 +102,7 @@ Client.prototype.set = function(key, value, callback) {
 // through the second argument to the callback. The operation
 // only succeeds if the key is not already present in the cache.
 Client.prototype.add = function(key, value, callback) {
-  var extras = '\0\0\0\0' + makeExpiration(this.options.expires);
+  var extras = Buffer.concat([new Buffer('00000000', 'hex'), makeExpiration(this.options.expires)]);
   var request = makeRequestBuffer(2, key, extras, value);
   var serv = this.server(key);
   var logger = this.options.logger;
@@ -129,7 +129,7 @@ Client.prototype.add = function(key, value, callback) {
 // through the second argument to the callback. The operation
 // only succeeds if the key is already present in the cache.
 Client.prototype.replace = function(key, value, callback) {
-  var extras = '\0\0\0\0' + makeExpiration(this.options.expires);
+  var extras = Buffer.concat([new Buffer('00000000', 'hex'), makeExpiration(this.options.expires)]);
   var request = makeRequestBuffer(3, key, extras, value);
   var serv = this.server(key);
   var logger = this.options.logger;

--- a/lib/memjs/utils.js
+++ b/lib/memjs/utils.js
@@ -27,7 +27,7 @@ exports.makeRequestBuffer = function(opcode, key, extras, value) {
 exports.makeExpiration = function(expiration) {
   var buf = new Buffer(4);
   buf.writeUInt32BE(expiration, 0);
-  return buf.toString()
+  return buf
 }
 
 exports.hashCode = function(str) {


### PR DESCRIPTION
Whenever I set an expire time in my instance it seems like the SET throws an "Invalid arguments" error. I'm using MemJS 0.4.0 and Memcached 1.4.15.

Can anyone else confirm or deny? Seem to have the same error on my Heroku instance.
