### PR TITLE
Key hashing can lead to undefined server references

### DIFF
--- a/lib/memjs/utils.js
+++ b/lib/memjs/utils.js
@@ -34,7 +34,7 @@ exports.hashCode = function(str) {
   for(var ret = 0, i = 0, len = str.length; i < len; i++) {
     ret = (31 * ret + str.charCodeAt(i)) << 0;
   }
-  return ret;
+  return Math.abs(ret);
 };
 
 exports.parseMessage = function(dataBuf) {


### PR DESCRIPTION
Because utils.hashCode() can sometimes return negative values, and Client.prototype.server() uses a mod to get the server index, certain keys map to an undefined server.

To reproduce:
`utils.hashCode("ffffff") // returns -1277454784`
