### PR TITLE
Add support for setting binary data

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -132,11 +132,16 @@ Client.prototype.get = function(key, callback) {
 // `Client.create`). The callback signature is:
 //
 //     callback(err, success)
-Client.prototype.set = function(key, value, callback, expires) {
+Client.prototype.set = function(key, value, callback, expires, binary) {
   var extras = Buffer.concat([new Buffer('00000000', 'hex'),
                               makeExpiration(expires || this.options.expires)]);
   this.seq++;
-  var request = makeRequestBuffer(1, key, extras, value.toString(), this.seq);
+  
+  if (!binary) {
+	  value = value.toString();
+  }
+  
+  var request = makeRequestBuffer(1, key, extras, value, this.seq);
   var logger = this.options.logger;
   this.perform(key, request, function(err, response) {
     if (err) {
@@ -163,10 +168,14 @@ Client.prototype.set = function(key, value, callback, expires) {
 // `Client.create`). The callback signature is:
 //
 //     callback(err, success)
-Client.prototype.add = function(key, value, callback, expires) {
+Client.prototype.add = function(key, value, callback, expires, binary) {
   var extras = Buffer.concat([new Buffer('00000000', 'hex'), makeExpiration(expires || this.options.expires)]);
   this.seq++;
-  var request = makeRequestBuffer(2, key, extras, value.toString(), this.seq);
+  
+  if (!binary) {
+	  value = value.toString();
+  }
+  var request = makeRequestBuffer(2, key, extras, value, this.seq);
   var logger = this.options.logger;
   this.perform(key, request, function(err, response) {
     if (err) {
@@ -196,10 +205,13 @@ Client.prototype.add = function(key, value, callback, expires) {
 // `Client.create`). The callback signature is:
 //
 //     callback(err, success)
-Client.prototype.replace = function(key, value, callback, expires) {
+Client.prototype.replace = function(key, value, callback, expires, binary) {
   var extras = Buffer.concat([new Buffer('00000000', 'hex'), makeExpiration(expires || this.options.expires)]);
   this.seq++;
-  var request = makeRequestBuffer(3, key, extras, value.toString(), this.seq);
+  if (!binary) {
+	  value = value.toString();
+  }
+  var request = makeRequestBuffer(3, key, extras, value, this.seq);
   var logger = this.options.logger;
   this.perform(key, request, function(err, response) {
     if (err) {


### PR DESCRIPTION
I'm working on a project that required me to cache images in memcache. The toString() call on the data variable passed into set() corrupted the image. 

I added an optional binary parameter to set, add, and replace. If binary is not specified, it defaults to calling toString() on the data.
