### PR TITLE
Don't force value to be a buffer

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -136,7 +136,7 @@ Client.prototype.set = function(key, value, callback, expires) {
   var extras = Buffer.concat([new Buffer('00000000', 'hex'),
                               makeExpiration(expires || this.options.expires)]);
   this.seq++;
-  var request = makeRequestBuffer(1, key, extras, value.toString(), this.seq);
+  var request = makeRequestBuffer(1, key, extras, value, this.seq);
   var logger = this.options.logger;
   this.perform(key, request, function(err, response) {
     if (err) {
@@ -166,7 +166,7 @@ Client.prototype.set = function(key, value, callback, expires) {
 Client.prototype.add = function(key, value, callback, expires) {
   var extras = Buffer.concat([new Buffer('00000000', 'hex'), makeExpiration(expires || this.options.expires)]);
   this.seq++;
-  var request = makeRequestBuffer(2, key, extras, value.toString(), this.seq);
+  var request = makeRequestBuffer(2, key, extras, value, this.seq);
   var logger = this.options.logger;
   this.perform(key, request, function(err, response) {
     if (err) {
@@ -199,7 +199,7 @@ Client.prototype.add = function(key, value, callback, expires) {
 Client.prototype.replace = function(key, value, callback, expires) {
   var extras = Buffer.concat([new Buffer('00000000', 'hex'), makeExpiration(expires || this.options.expires)]);
   this.seq++;
-  var request = makeRequestBuffer(3, key, extras, value.toString(), this.seq);
+  var request = makeRequestBuffer(3, key, extras, value, this.seq);
   var logger = this.options.logger;
   this.perform(key, request, function(err, response) {
     if (err) {


### PR DESCRIPTION
Based on @4ndr3w's pull request, `set`, `add`, `replace` etc were forcing the value to a string, which doesn't play well with binary data. There is no need as `makeRequestBuffer` accepts either `Buffer`s or anything that can be passed to the constructor of a `Buffer` (e.g. a `String`).
