### PR TITLE
[Documentation link] : New link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ MemJS is a pure Node.js client library for using memcache, in particular, the
 [MemCachier](http://memcachier.com/) service. It
 uses the binary protocol and support SASL authentication.
 
-Documentation can be found here: [https://memjs.netlify.com/](https://memjs.netlify.com/)
+Documentation can be found here: [http://amitlevy.com/projects/memjs/](http://amitlevy.com/projects/memjs/)
 
 ## TOC
 


### PR DESCRIPTION
Replaced the documentation link to http://amitlevy.com/projects/memjs. As https://memjs.netlify.com/ gives "Page not found"