### PR TITLE
New Buffer Deprecation

### DIFF
--- a/lib/memjs/buffer.js
+++ b/lib/memjs/buffer.js
@@ -1,0 +1,63 @@
+// # MemJS Memcache node buffer operations
+
+// Before node v5.10.0 alloc() and from() did not exist
+// this is a way to make sure that memjs works for previous versions
+// in a safe manner
+if (!Buffer.alloc) {
+  exports.alloc = function(size) {
+    var buf = new Buffer(size);
+    buf.fill();
+    return buf;
+  };
+
+  exports.from = function(value, encodingOrOffset, length) {
+    return new Buffer(value, encodingOrOffset, length);
+  };
+} else {
+  exports.alloc = Buffer.alloc;
+  exports.from = Buffer.from; 
+}
+
+
+// Node Buffer.concat was not added until node v0.7.11
+// this is a way to add backwards compatability
+if(!Buffer.concat) {
+  exports.concat = function(list, length) {
+    if (!Array.isArray(list)) {
+      throw new Error('Usage: concatNodeBuffer(list, [length])');
+    }
+
+    if (list.length === 0) {
+      return new Buffer(0);
+    }
+    if (list.length === 1) {
+      return list[0];
+    }
+
+    var i, buf;
+
+    if (typeof length !== 'number') {
+      length = 0;
+      for (i = 0; i < list.length; i++) {
+        buf = list[i];
+        length += buf.length;
+      }
+    }
+
+    var buffer = new Buffer(length);
+    buffer.fill();
+    var pos = 0;
+    for (i = 0; i < list.length; i++) {
+      buf = list[i];
+      buf.copy(buffer, pos);
+      pos += buf.length;
+    }
+    return buffer;
+  };
+} else {
+  exports.concat = Buffer.concat;
+}
+
+exports.bufferify = function(val) {
+  return Buffer.isBuffer(val) ? val : exports.from(val);
+};

--- a/lib/memjs/header.js
+++ b/lib/memjs/header.js
@@ -20,8 +20,7 @@ exports.fromBuffer = function(headerBuf) {
 
 // toBuffer converts a JS memcache header object to a binary memcache header
 exports.toBuffer = function(header) {
-  var headerBuf = new Buffer(24);
-  headerBuf.fill();
+  var headerBuf = Buffer.alloc(24);
   headerBuf.writeUInt8(header.magic, 0);
   headerBuf.writeUInt8(header.opcode, 1);
   headerBuf.writeUInt16BE(header.keyLength, 2);

--- a/lib/memjs/header.js
+++ b/lib/memjs/header.js
@@ -1,5 +1,7 @@
 // # MemJS Memcache binary protocol header
 
+var memjsBuffer = require('./buffer');
+
 // fromBuffer converts a serialized header to a JS object.
 exports.fromBuffer = function(headerBuf) {
   if (!headerBuf) {
@@ -20,7 +22,7 @@ exports.fromBuffer = function(headerBuf) {
 
 // toBuffer converts a JS memcache header object to a binary memcache header
 exports.toBuffer = function(header) {
-  var headerBuf = Buffer.alloc(24);
+  var headerBuf = memjsBuffer.alloc(24);
   headerBuf.writeUInt8(header.magic, 0);
   headerBuf.writeUInt8(header.opcode, 1);
   headerBuf.writeUInt16BE(header.keyLength, 2);

--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -181,7 +181,7 @@ Client.prototype.set = function(key, value, options, callback) {
   // TODO: support flags, support version (CAS)
   this.seq++;
   var expiration = makeExpiration(expires || this.options.expires);
-  var extras = Buffer.concat([new Buffer('00000000', 'hex'), expiration]);
+  var extras = Buffer.concat([Buffer.from('00000000', 'hex'), expiration]);
   var request = makeRequestBuffer(1, key, extras, value, this.seq);
   this.perform(key, request, this.seq, function(err, response) {
     if (err) {
@@ -233,7 +233,7 @@ Client.prototype.add = function(key, value, options, callback) {
   // TODO: support flags, support version (CAS)
   this.seq++;
   var expiration = makeExpiration(expires || this.options.expires);
-  var extras = Buffer.concat([new Buffer('00000000', 'hex'), expiration]);
+  var extras = Buffer.concat([Buffer.from('00000000', 'hex'), expiration]);
   var request = makeRequestBuffer(2, key, extras, value, this.seq);
   this.perform(key, request, this.seq, function(err, response) {
     if (err) {
@@ -288,7 +288,7 @@ Client.prototype.replace = function(key, value, options, callback) {
   // TODO: support flags, support version (CAS)
   this.seq++;
   var expiration = makeExpiration(expires || this.options.expires);
-  var extras = Buffer.concat([new Buffer('00000000', 'hex'), expiration]);
+  var extras = Buffer.concat([Buffer.from('00000000', 'hex'), expiration]);
   var request = makeRequestBuffer(3, key, extras, value, this.seq);
   this.perform(key, request, this.seq, function(err, response) {
     if (err) {

--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -7,6 +7,7 @@ var hashCode = require('./utils').hashCode;
 var merge = require('./utils').merge;
 var makeExpiration = require('./utils').makeExpiration;
 var makeAmountInitialAndExpiration = require('./utils').makeAmountInitialAndExpiration;
+var memjsBuffer = require('./buffer');
 
 // Client initializer takes a list of `Server`s and an `options` dictionary.
 // See `Client.create` for details.
@@ -181,7 +182,7 @@ Client.prototype.set = function(key, value, options, callback) {
   // TODO: support flags, support version (CAS)
   this.seq++;
   var expiration = makeExpiration(expires || this.options.expires);
-  var extras = Buffer.concat([Buffer.from('00000000', 'hex'), expiration]);
+  var extras = memjsBuffer.concat([memjsBuffer.from('00000000', 'hex'), expiration]);
   var request = makeRequestBuffer(1, key, extras, value, this.seq);
   this.perform(key, request, this.seq, function(err, response) {
     if (err) {
@@ -233,7 +234,7 @@ Client.prototype.add = function(key, value, options, callback) {
   // TODO: support flags, support version (CAS)
   this.seq++;
   var expiration = makeExpiration(expires || this.options.expires);
-  var extras = Buffer.concat([Buffer.from('00000000', 'hex'), expiration]);
+  var extras = memjsBuffer.concat([memjsBuffer.from('00000000', 'hex'), expiration]);
   var request = makeRequestBuffer(2, key, extras, value, this.seq);
   this.perform(key, request, this.seq, function(err, response) {
     if (err) {
@@ -288,7 +289,7 @@ Client.prototype.replace = function(key, value, options, callback) {
   // TODO: support flags, support version (CAS)
   this.seq++;
   var expiration = makeExpiration(expires || this.options.expires);
-  var extras = Buffer.concat([Buffer.from('00000000', 'hex'), expiration]);
+  var extras = memjsBuffer.concat([memjsBuffer.from('00000000', 'hex'), expiration]);
   var request = makeRequestBuffer(3, key, extras, value, this.seq);
   this.perform(key, request, this.seq, function(err, response) {
     if (err) {

--- a/lib/memjs/server.js
+++ b/lib/memjs/server.js
@@ -5,10 +5,11 @@ var makeRequestBuffer = require('./utils').makeRequestBuffer;
 var parseMessage = require('./utils').parseMessage;
 var merge = require('./utils').merge;
 var timestamp = require('./utils').timestamp;
+var memjsBuffer = require('./buffer');
 
 var Server = function(host, port, username, password, options) {
   events.EventEmitter.call(this);
-  this.responseBuffer = new Buffer([]);
+  this.responseBuffer = memjsBuffer.alloc(0);
   this.host = host;
   this.port = port;
   this.connected = false;
@@ -86,7 +87,7 @@ Server.prototype.saslAuth = function() {
 
 Server.prototype.appendToBuffer = function(dataBuf) {
   var old = this.responseBuffer;
-  this.responseBuffer = new Buffer(old.length + dataBuf.length);
+  this.responseBuffer = memjsBuffer.alloc(old.length + dataBuf.length);
   old.copy(this.responseBuffer, 0);
   dataBuf.copy(this.responseBuffer, old.length);
   return this.responseBuffer;

--- a/lib/memjs/utils.js
+++ b/lib/memjs/utils.js
@@ -2,16 +2,29 @@
 
 var header = require('./header');
 
+if (!Buffer.alloc) {
+  Buffer.alloc = function(size) {
+    var buf = new Buffer(size);
+    buf.fill();
+    return buf;
+  };
+}
+
+if (!Buffer.from) {
+  Buffer.from = function(value, encodingOrOffset, length) {
+    return new Buffer(value, encodingOrOffset, length);
+  };
+}
+
 var bufferify = function(val) {
-  return Buffer.isBuffer(val) ? val : new Buffer(val);
+  return Buffer.isBuffer(val) ? val : Buffer.from(val);
 };
 
 exports.makeRequestBuffer = function(opcode, key, extras, value, opaque) {
   key = bufferify(key);
   extras = bufferify(extras);
   value = bufferify(value);
-  var buf = new Buffer(24 + key.length + extras.length + value.length);
-  buf.fill();
+  var buf = Buffer.alloc(24 + key.length + extras.length + value.length);
   var requestHeader = {
     magic: 0x80,
     opcode: opcode,
@@ -28,7 +41,7 @@ exports.makeRequestBuffer = function(opcode, key, extras, value, opaque) {
 };
 
 exports.makeAmountInitialAndExpiration = function(amount, amountIfEmpty, expiration) {
-  var buf = new Buffer(20);
+  var buf = Buffer.alloc(20);
   buf.writeUInt32BE(0, 0);
   buf.writeUInt32BE(amount, 4);
   buf.writeUInt32BE(0, 8);
@@ -38,7 +51,7 @@ exports.makeAmountInitialAndExpiration = function(amount, amountIfEmpty, expirat
 };
 
 exports.makeExpiration = function(expiration) {
-  var buf = new Buffer(4);
+  var buf = Buffer.alloc(4);
   buf.writeUInt32BE(expiration, 0);
   return buf;
 };

--- a/lib/memjs/utils.js
+++ b/lib/memjs/utils.js
@@ -1,30 +1,14 @@
 // # MemJS utility functions
 
+var memjsBuffer = require('./buffer');
+var bufferify = require('./buffer').bufferify;
 var header = require('./header');
-
-if (!Buffer.alloc) {
-  Buffer.alloc = function(size) {
-    var buf = new Buffer(size);
-    buf.fill();
-    return buf;
-  };
-}
-
-if (!Buffer.from) {
-  Buffer.from = function(value, encodingOrOffset, length) {
-    return new Buffer(value, encodingOrOffset, length);
-  };
-}
-
-var bufferify = function(val) {
-  return Buffer.isBuffer(val) ? val : Buffer.from(val);
-};
 
 exports.makeRequestBuffer = function(opcode, key, extras, value, opaque) {
   key = bufferify(key);
   extras = bufferify(extras);
   value = bufferify(value);
-  var buf = Buffer.alloc(24 + key.length + extras.length + value.length);
+  var buf = memjsBuffer.alloc(24 + key.length + extras.length + value.length);
   var requestHeader = {
     magic: 0x80,
     opcode: opcode,
@@ -41,7 +25,7 @@ exports.makeRequestBuffer = function(opcode, key, extras, value, opaque) {
 };
 
 exports.makeAmountInitialAndExpiration = function(amount, amountIfEmpty, expiration) {
-  var buf = Buffer.alloc(20);
+  var buf = memjsBuffer.alloc(20);
   buf.writeUInt32BE(0, 0);
   buf.writeUInt32BE(amount, 4);
   buf.writeUInt32BE(0, 8);
@@ -51,7 +35,7 @@ exports.makeAmountInitialAndExpiration = function(amount, amountIfEmpty, expirat
 };
 
 exports.makeExpiration = function(expiration) {
-  var buf = Buffer.alloc(4);
+  var buf = memjsBuffer.alloc(4);
   buf.writeUInt32BE(expiration, 0);
   return buf;
 };
@@ -106,36 +90,3 @@ exports.timestamp = function() {
   return (times[0] * 1000) + Math.round((times[1] / 1000000));
 };
 
-if(!Buffer.concat) {
-  Buffer.concat = function(list, length) {
-    if (!Array.isArray(list)) {
-      throw new Error('Usage: Buffer.concat(list, [length])');
-    }
-
-    if (list.length === 0) {
-      return new Buffer(0);
-    }
-    if (list.length === 1) {
-      return list[0];
-    }
-
-    var i, buf;
-
-    if (typeof length !== 'number') {
-      length = 0;
-      for (i = 0; i < list.length; i++) {
-        buf = list[i];
-        length += buf.length;
-      }
-    }
-
-    var buffer = new Buffer(length);
-    var pos = 0;
-    for (i = 0; i < list.length; i++) {
-      buf = list[i];
-      buf.copy(buffer, pos);
-      pos += buf.length;
-    }
-    return buffer;
-  };
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -63,8 +63,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -73,7 +73,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -82,8 +82,8 @@
       "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-slice": "0.2.3"
+        "arr-flatten": "^1.0.1",
+        "array-slice": "^0.2.3"
       }
     },
     "arr-flatten": {
@@ -104,7 +104,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -171,7 +171,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "benchmark": {
@@ -180,8 +180,8 @@
       "integrity": "sha1-hnFkTXVD2mUM7UbPr+jMP5g022o=",
       "dev": true,
       "requires": {
-        "lodash": "3.10.1",
-        "platform": "1.3.4"
+        "lodash": "^3.10.1",
+        "platform": "^1.3.1"
       }
     },
     "bindings": {
@@ -196,7 +196,7 @@
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.5"
       }
     },
     "boom": {
@@ -205,7 +205,7 @@
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "dev": true,
       "requires": {
-        "hoek": "0.9.1"
+        "hoek": "0.9.x"
       }
     },
     "brace-expansion": {
@@ -214,7 +214,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -224,9 +224,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "builtin-modules": {
@@ -241,9 +241,9 @@
       "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
       "dev": true,
       "requires": {
-        "md5-hex": "1.3.0",
-        "mkdirp": "0.5.1",
-        "write-file-atomic": "1.3.4"
+        "md5-hex": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "write-file-atomic": "^1.1.4"
       }
     },
     "camelcase": {
@@ -266,8 +266,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -276,11 +276,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chownr": {
@@ -301,7 +301,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-width": {
@@ -317,8 +317,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -387,9 +387,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "console-control-strings": {
@@ -441,7 +441,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "caseless": {
@@ -456,7 +456,7 @@
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "cryptiles": {
@@ -465,7 +465,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "delayed-stream": {
@@ -492,9 +492,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "hawk": {
@@ -503,10 +503,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -521,9 +521,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "js-yaml": {
@@ -532,8 +532,8 @@
           "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
           }
         },
         "mime-types": {
@@ -542,7 +542,7 @@
           "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "dev": true,
           "requires": {
-            "mime-db": "1.30.0"
+            "mime-db": "~1.30.0"
           }
         },
         "minimist": {
@@ -569,26 +569,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.3.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1",
+            "uuid": "^3.0.0"
           }
         },
         "sntp": {
@@ -597,7 +597,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "tunnel-agent": {
@@ -620,8 +620,8 @@
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -631,7 +631,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "boom": "0.4.2"
+        "boom": "0.4.x"
       }
     },
     "ctype": {
@@ -647,7 +647,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.37"
+        "es5-ext": "^0.10.9"
       }
     },
     "dashdash": {
@@ -656,7 +656,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -718,13 +718,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -752,11 +752,11 @@
       "integrity": "sha512-QcWBDnnGaT+rgC0wqynznXv0/4hd6nAFdWNs2fN4FvkH2yAnCYVeRU7GIZXNCeUQ955Lufq+TmZcSXiBa1cGQQ==",
       "dev": true,
       "requires": {
-        "commander": "2.12.1",
-        "fs-extra": "5.0.0",
-        "highlight.js": "9.12.0",
-        "marked": "0.3.9",
-        "underscore": "1.8.3"
+        "commander": ">= 0.5.2",
+        "fs-extra": ">= 0.6.0",
+        "highlight.js": ">= 8.0.x",
+        "marked": ">= 0.2.7",
+        "underscore": ">= 1.0.0"
       }
     },
     "doctrine": {
@@ -765,7 +765,7 @@
       "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
       "dev": true,
       "requires": {
-        "esutils": "1.1.6",
+        "esutils": "^1.1.6",
         "isarray": "0.0.1"
       },
       "dependencies": {
@@ -796,7 +796,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "end-of-stream": {
@@ -805,7 +805,7 @@
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "error-ex": {
@@ -814,7 +814,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es5-ext": {
@@ -823,8 +823,8 @@
       "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "~3.1.1"
       }
     },
     "es6-iterator": {
@@ -833,9 +833,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -844,12 +844,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-set": {
@@ -858,11 +858,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -871,8 +871,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -881,10 +881,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -899,11 +899,11 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       },
       "dependencies": {
         "esprima": {
@@ -930,8 +930,8 @@
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
           "dev": true,
           "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
           }
         },
         "optionator": {
@@ -940,12 +940,12 @@
           "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
           "dev": true,
           "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
           }
         },
         "source-map": {
@@ -955,7 +955,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "wordwrap": {
@@ -972,10 +972,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -984,39 +984,39 @@
       "integrity": "sha1-+xmpGxPBWAgrvKKUsX2Xm8g1Ogo=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.9",
-        "doctrine": "0.7.2",
-        "escape-string-regexp": "1.0.5",
-        "escope": "3.6.0",
-        "espree": "2.2.5",
-        "estraverse": "4.2.0",
-        "estraverse-fb": "1.3.2",
-        "esutils": "2.0.2",
-        "file-entry-cache": "1.3.1",
-        "glob": "5.0.15",
-        "globals": "8.18.0",
-        "handlebars": "4.0.11",
-        "inquirer": "0.11.4",
-        "is-my-json-valid": "2.16.1",
-        "is-resolvable": "1.0.0",
+        "chalk": "^1.0.0",
+        "concat-stream": "^1.4.6",
+        "debug": "^2.1.1",
+        "doctrine": "^0.7.1",
+        "escape-string-regexp": "^1.0.2",
+        "escope": "^3.3.0",
+        "espree": "^2.2.4",
+        "estraverse": "^4.1.1",
+        "estraverse-fb": "^1.3.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^1.1.1",
+        "glob": "^5.0.14",
+        "globals": "^8.11.0",
+        "handlebars": "^4.0.0",
+        "inquirer": "^0.11.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
         "js-yaml": "3.4.5",
-        "json-stable-stringify": "1.0.1",
-        "lodash.clonedeep": "3.0.2",
-        "lodash.merge": "3.3.2",
-        "lodash.omit": "3.1.0",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "optionator": "0.6.0",
-        "path-is-absolute": "1.0.1",
-        "path-is-inside": "1.0.2",
-        "shelljs": "0.5.3",
-        "strip-json-comments": "1.0.4",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0",
-        "xml-escape": "1.0.0"
+        "json-stable-stringify": "^1.0.0",
+        "lodash.clonedeep": "^3.0.1",
+        "lodash.merge": "^3.3.2",
+        "lodash.omit": "^3.1.0",
+        "minimatch": "^3.0.0",
+        "mkdirp": "^0.5.0",
+        "object-assign": "^4.0.1",
+        "optionator": "^0.6.0",
+        "path-is-absolute": "^1.0.0",
+        "path-is-inside": "^1.0.1",
+        "shelljs": "^0.5.3",
+        "strip-json-comments": "~1.0.1",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0",
+        "xml-escape": "~1.0.0"
       }
     },
     "espree": {
@@ -1031,8 +1031,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -1059,8 +1059,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.37"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "events-to-array": {
@@ -1081,7 +1081,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -1090,7 +1090,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-template": {
@@ -1123,8 +1123,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -1133,8 +1133,8 @@
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "filename-regex": {
@@ -1149,11 +1149,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "find-cache-dir": {
@@ -1162,9 +1162,9 @@
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
       "dev": true,
       "requires": {
-        "commondir": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pkg-dir": "1.0.0"
+        "commondir": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pkg-dir": "^1.0.0"
       }
     },
     "find-up": {
@@ -1173,8 +1173,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -1183,10 +1183,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "for-in": {
@@ -1201,7 +1201,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreground-child": {
@@ -1210,8 +1210,8 @@
       "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
       "dev": true,
       "requires": {
-        "cross-spawn": "4.0.2",
-        "signal-exit": "3.0.2"
+        "cross-spawn": "^4",
+        "signal-exit": "^3.0.0"
       }
     },
     "forever-agent": {
@@ -1227,9 +1227,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "async": "0.9.2",
-        "combined-stream": "0.0.7",
-        "mime": "1.2.11"
+        "async": "~0.9.0",
+        "combined-stream": "~0.0.4",
+        "mime": "~1.2.11"
       },
       "dependencies": {
         "async": {
@@ -1247,9 +1247,9 @@
       "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -1264,14 +1264,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "generate-function": {
@@ -1286,7 +1286,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "getpass": {
@@ -1295,7 +1295,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -1318,11 +1318,11 @@
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "dev": true,
       "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -1331,8 +1331,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-glob": {
@@ -1341,7 +1341,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -1352,7 +1352,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-glob": {
@@ -1361,7 +1361,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -1378,12 +1378,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "glob": {
@@ -1392,12 +1392,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -1414,10 +1414,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       }
     },
     "har-validator": {
@@ -1426,10 +1426,10 @@
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.12.1",
-        "is-my-json-valid": "2.16.1",
-        "pinkie-promise": "2.0.1"
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -1438,7 +1438,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -1460,10 +1460,10 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "boom": "0.4.2",
-        "cryptiles": "0.2.2",
-        "hoek": "0.9.1",
-        "sntp": "0.2.4"
+        "boom": "0.4.x",
+        "cryptiles": "0.2.x",
+        "hoek": "0.9.x",
+        "sntp": "0.2.x"
       }
     },
     "highlight.js": {
@@ -1492,7 +1492,7 @@
       "optional": true,
       "requires": {
         "asn1": "0.1.11",
-        "assert-plus": "0.1.5",
+        "assert-plus": "^0.1.5",
         "ctype": "0.5.3"
       }
     },
@@ -1508,8 +1508,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1530,19 +1530,19 @@
       "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "1.1.1",
-        "figures": "1.7.0",
-        "lodash": "3.10.1",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^1.0.1",
+        "figures": "^1.3.5",
+        "lodash": "^3.3.1",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       }
     },
     "invert-kv": {
@@ -1569,7 +1569,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-dotfile": {
@@ -1584,7 +1584,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extglob": {
@@ -1599,7 +1599,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -1614,10 +1614,10 @@
       "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-number": {
@@ -1626,7 +1626,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-path-cwd": {
@@ -1641,7 +1641,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -1650,7 +1650,7 @@
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-posix-bracket": {
@@ -1677,7 +1677,7 @@
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
-        "tryit": "1.0.3"
+        "tryit": "^1.0.1"
       }
     },
     "is-typedarray": {
@@ -1725,20 +1725,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.4.5",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.0",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -1753,7 +1753,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "wordwrap": {
@@ -1770,8 +1770,8 @@
       "integrity": "sha1-w0A3l98SuRhmV08t4jZG/oyvtE0=",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "2.7.3"
+        "argparse": "^1.0.2",
+        "esprima": "^2.6.0"
       },
       "dependencies": {
         "esprima": {
@@ -1801,7 +1801,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -1816,7 +1816,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -1857,7 +1857,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -1873,7 +1873,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lcov-parse": {
@@ -1888,8 +1888,8 @@
       "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.0",
+        "type-check": "~0.3.1"
       }
     },
     "load-json-file": {
@@ -1898,11 +1898,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       }
     },
     "lodash": {
@@ -1935,8 +1935,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._baseclone": {
@@ -1945,12 +1945,12 @@
       "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
       "dev": true,
       "requires": {
-        "lodash._arraycopy": "3.0.0",
-        "lodash._arrayeach": "3.0.0",
-        "lodash._baseassign": "3.2.0",
-        "lodash._basefor": "3.0.3",
-        "lodash.isarray": "3.0.4",
-        "lodash.keys": "3.1.2"
+        "lodash._arraycopy": "^3.0.0",
+        "lodash._arrayeach": "^3.0.0",
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -1965,9 +1965,9 @@
       "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
       "dev": true,
       "requires": {
-        "lodash._baseindexof": "3.1.0",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2"
+        "lodash._baseindexof": "^3.0.0",
+        "lodash._cacheindexof": "^3.0.0",
+        "lodash._createcache": "^3.0.0"
       }
     },
     "lodash._baseflatten": {
@@ -1976,8 +1976,8 @@
       "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
       "dev": true,
       "requires": {
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash._basefor": {
@@ -2010,9 +2010,9 @@
       "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
       "dev": true,
       "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       }
     },
     "lodash._createcache": {
@@ -2021,7 +2021,7 @@
       "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1"
+        "lodash._getnative": "^3.0.0"
       }
     },
     "lodash._getnative": {
@@ -2048,8 +2048,8 @@
       "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
       "dev": true,
       "requires": {
-        "lodash._basefor": "3.0.3",
-        "lodash.keysin": "3.0.8"
+        "lodash._basefor": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
       }
     },
     "lodash.clonedeep": {
@@ -2058,8 +2058,8 @@
       "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
       "dev": true,
       "requires": {
-        "lodash._baseclone": "3.3.0",
-        "lodash._bindcallback": "3.0.1"
+        "lodash._baseclone": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0"
       }
     },
     "lodash.isarguments": {
@@ -2080,9 +2080,9 @@
       "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
       "dev": true,
       "requires": {
-        "lodash._basefor": "3.0.3",
-        "lodash.isarguments": "3.1.0",
-        "lodash.keysin": "3.0.8"
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
       }
     },
     "lodash.istypedarray": {
@@ -2097,9 +2097,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.keysin": {
@@ -2108,8 +2108,8 @@
       "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
       "dev": true,
       "requires": {
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.merge": {
@@ -2118,17 +2118,17 @@
       "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
       "dev": true,
       "requires": {
-        "lodash._arraycopy": "3.0.0",
-        "lodash._arrayeach": "3.0.0",
-        "lodash._createassigner": "3.1.1",
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4",
-        "lodash.isplainobject": "3.2.0",
-        "lodash.istypedarray": "3.0.6",
-        "lodash.keys": "3.1.2",
-        "lodash.keysin": "3.0.8",
-        "lodash.toplainobject": "3.0.0"
+        "lodash._arraycopy": "^3.0.0",
+        "lodash._arrayeach": "^3.0.0",
+        "lodash._createassigner": "^3.0.0",
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.isplainobject": "^3.0.0",
+        "lodash.istypedarray": "^3.0.0",
+        "lodash.keys": "^3.0.0",
+        "lodash.keysin": "^3.0.0",
+        "lodash.toplainobject": "^3.0.0"
       }
     },
     "lodash.omit": {
@@ -2137,14 +2137,14 @@
       "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
       "dev": true,
       "requires": {
-        "lodash._arraymap": "3.0.0",
-        "lodash._basedifference": "3.0.3",
-        "lodash._baseflatten": "3.1.4",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._pickbyarray": "3.0.2",
-        "lodash._pickbycallback": "3.0.0",
-        "lodash.keysin": "3.0.8",
-        "lodash.restparam": "3.6.1"
+        "lodash._arraymap": "^3.0.0",
+        "lodash._basedifference": "^3.0.0",
+        "lodash._baseflatten": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash._pickbyarray": "^3.0.0",
+        "lodash._pickbycallback": "^3.0.0",
+        "lodash.keysin": "^3.0.0",
+        "lodash.restparam": "^3.0.0"
       }
     },
     "lodash.restparam": {
@@ -2159,8 +2159,8 @@
       "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keysin": "3.0.8"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
       }
     },
     "log-driver": {
@@ -2181,8 +2181,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "marked": {
@@ -2197,7 +2197,7 @@
       "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
       "dev": true,
       "requires": {
-        "md5-o-matic": "0.1.1"
+        "md5-o-matic": "^0.1.1"
       }
     },
     "md5-o-matic": {
@@ -2212,16 +2212,16 @@
       "integrity": "sha1-UaZancv7khEykqBx4E2jWoHpBQ4=",
       "dev": true,
       "requires": {
-        "arr-diff": "1.1.0",
-        "braces": "1.8.5",
-        "debug": "2.6.9",
-        "expand-brackets": "0.1.5",
-        "filename-regex": "2.0.1",
-        "is-glob": "1.1.3",
-        "kind-of": "1.1.0",
-        "object.omit": "0.2.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^1.0.1",
+        "braces": "^1.8.0",
+        "debug": "^2.1.3",
+        "expand-brackets": "^0.1.1",
+        "filename-regex": "^2.0.0",
+        "is-glob": "^1.1.3",
+        "kind-of": "^1.1.0",
+        "object.omit": "^0.2.1",
+        "parse-glob": "^3.0.0",
+        "regex-cache": "^0.4.0"
       },
       "dependencies": {
         "kind-of": {
@@ -2238,9 +2238,9 @@
       "integrity": "sha1-CQT251Xmp0UFUsGR9AmeIxy1+mw=",
       "dev": true,
       "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.8.0",
-        "prebuild-install": "2.4.1"
+        "bindings": "1.3.x",
+        "nan": "2.8.x",
+        "prebuild-install": "^2.1.0"
       }
     },
     "mime": {
@@ -2268,7 +2268,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2310,7 +2310,7 @@
       "integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
       "dev": true,
       "requires": {
-        "semver": "5.4.1"
+        "semver": "^5.4.1"
       }
     },
     "node-uuid": {
@@ -2331,7 +2331,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -2340,10 +2340,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "npmlog": {
@@ -2352,10 +2352,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -2370,26 +2370,26 @@
       "integrity": "sha1-DrOU0W8++f8bRA/ZOxp6tTAJJ1Q=",
       "dev": true,
       "requires": {
-        "append-transform": "0.2.2",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.5.1",
-        "find-cache-dir": "0.1.1",
-        "foreground-child": "1.5.6",
-        "glob": "6.0.4",
-        "istanbul": "0.4.5",
-        "md5-hex": "1.3.0",
-        "micromatch": "2.1.6",
-        "mkdirp": "0.5.1",
-        "pkg-up": "1.0.0",
-        "read-pkg": "1.1.0",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.6.2",
-        "signal-exit": "2.1.2",
-        "source-map": "0.5.7",
-        "spawn-wrap": "1.4.1",
-        "strip-bom": "2.0.0",
-        "yargs": "3.32.0"
+        "append-transform": "^0.2.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^1.0.0",
+        "convert-source-map": "^1.1.2",
+        "find-cache-dir": "^0.1.1",
+        "foreground-child": "^1.3.5",
+        "glob": "^6.0.2",
+        "istanbul": "^0.4.1",
+        "md5-hex": "^1.2.0",
+        "micromatch": "~2.1.6",
+        "mkdirp": "^0.5.0",
+        "pkg-up": "^1.0.0",
+        "read-pkg": "^1.1.0",
+        "resolve-from": "^2.0.0",
+        "rimraf": "^2.5.0",
+        "signal-exit": "^2.1.1",
+        "source-map": "^0.5.3",
+        "spawn-wrap": "^1.1.1",
+        "strip-bom": "^2.0.0",
+        "yargs": "^3.15.0"
       },
       "dependencies": {
         "camelcase": {
@@ -2404,9 +2404,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "glob": {
@@ -2415,11 +2415,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "signal-exit": {
@@ -2446,13 +2446,13 @@
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "dev": true,
           "requires": {
-            "camelcase": "2.1.1",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "string-width": "1.0.2",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
           }
         }
       }
@@ -2476,8 +2476,8 @@
       "integrity": "sha1-ypr2Yx32iD/mG65034Kk+8nfLpI=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "isobject": "0.2.0"
+        "for-own": "^0.1.1",
+        "isobject": "^0.2.0"
       },
       "dependencies": {
         "isobject": {
@@ -2494,7 +2494,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -2521,8 +2521,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -2531,12 +2531,12 @@
       "integrity": "sha1-tj7Lvw4xX61LyYJ7Rdx7pFKE/LY=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "1.0.7",
-        "levn": "0.2.5",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "0.0.3"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~1.0.6",
+        "levn": "~0.2.5",
+        "prelude-ls": "~1.1.1",
+        "type-check": "~0.3.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "os-homedir": {
@@ -2551,7 +2551,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "parse-glob": {
@@ -2560,10 +2560,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-glob": {
@@ -2572,7 +2572,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -2583,7 +2583,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "path-exists": {
@@ -2592,7 +2592,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -2613,9 +2613,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "pify": {
@@ -2636,7 +2636,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -2645,7 +2645,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "pkg-up": {
@@ -2654,7 +2654,7 @@
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "platform": {
@@ -2669,19 +2669,19 @@
       "integrity": "sha512-99TyEFYTTkBWANT+mwSptmLb9ZCLQ6qKIUE36fXSIOtShB0JNprL2hzBD8F1yIuT9btjFrFEwbRHXhqDi1HmRA==",
       "dev": true,
       "requires": {
-        "expand-template": "1.1.0",
+        "expand-template": "^1.0.2",
         "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.1.2",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "1.0.3",
-        "rc": "1.2.2",
-        "simple-get": "1.4.3",
-        "tar-fs": "1.16.0",
-        "tunnel-agent": "0.6.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-abi": "^2.1.1",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^1.0.1",
+        "rc": "^1.1.6",
+        "simple-get": "^1.4.2",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
         "xtend": "4.0.1"
       },
       "dependencies": {
@@ -2723,8 +2723,8 @@
       "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.0",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -2745,8 +2745,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -2755,7 +2755,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2764,7 +2764,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -2775,7 +2775,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -2786,10 +2786,10 @@
       "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "dev": true,
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -2812,9 +2812,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -2823,13 +2823,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readline2": {
@@ -2838,8 +2838,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -2849,7 +2849,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "repeat-element": {
@@ -2870,21 +2870,21 @@
       "integrity": "sha1-VyvQFIk4VkBArHqxSLlkI6BjMEo=",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.5.0",
-        "bl": "0.9.5",
-        "caseless": "0.6.0",
-        "forever-agent": "0.5.2",
-        "form-data": "0.1.4",
+        "aws-sign2": "~0.5.0",
+        "bl": "~0.9.0",
+        "caseless": "~0.6.0",
+        "forever-agent": "~0.5.0",
+        "form-data": "~0.1.0",
         "hawk": "1.1.1",
-        "http-signature": "0.10.1",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "1.0.2",
-        "node-uuid": "1.4.8",
-        "oauth-sign": "0.4.0",
-        "qs": "1.2.2",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.4.3"
+        "http-signature": "~0.10.0",
+        "json-stringify-safe": "~5.0.0",
+        "mime-types": "~1.0.1",
+        "node-uuid": "~1.4.0",
+        "oauth-sign": "~0.4.0",
+        "qs": "~1.2.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": ">=0.12.0",
+        "tunnel-agent": "~0.4.0"
       },
       "dependencies": {
         "bl": {
@@ -2893,7 +2893,7 @@
           "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34"
+            "readable-stream": "~1.0.26"
           }
         },
         "isarray": {
@@ -2908,10 +2908,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -2946,8 +2946,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "resumer": {
@@ -2956,7 +2956,7 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3.4"
       }
     },
     "right-align": {
@@ -2966,7 +2966,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -2975,7 +2975,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       },
       "dependencies": {
         "glob": {
@@ -2984,12 +2984,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -3000,7 +3000,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "rx-lite": {
@@ -3045,9 +3045,9 @@
       "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "unzip-response": "1.0.2",
-        "xtend": "4.0.1"
+        "once": "^1.3.1",
+        "unzip-response": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "slide": {
@@ -3063,7 +3063,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "hoek": "0.9.1"
+        "hoek": "0.9.x"
       }
     },
     "source-map": {
@@ -3072,7 +3072,7 @@
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "dev": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "spawn-wrap": {
@@ -3081,12 +3081,12 @@
       "integrity": "sha512-QVNc3SeChKxc5ZUM3IGD7PsX6olPkdMFXHJ0UdjU3UBAKPRAiuSPCwvy8+lX2V9+LvqY5hFn8emdRuq3dUGPGw==",
       "dev": true,
       "requires": {
-        "foreground-child": "1.5.6",
-        "mkdirp": "0.5.1",
-        "os-homedir": "1.0.2",
-        "rimraf": "2.6.2",
-        "signal-exit": "3.0.2",
-        "which": "1.3.0"
+        "foreground-child": "^1.5.6",
+        "mkdirp": "^0.5.0",
+        "os-homedir": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.2",
+        "which": "^1.3.0"
       }
     },
     "spdx-correct": {
@@ -3095,7 +3095,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -3116,7 +3116,7 @@
       "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "sprintf-js": {
@@ -3131,14 +3131,14 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       },
       "dependencies": {
         "asn1": {
@@ -3161,7 +3161,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "~0.1.1"
       }
     },
     "string-width": {
@@ -3170,9 +3170,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -3181,7 +3181,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -3196,7 +3196,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -3205,7 +3205,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-json-comments": {
@@ -3226,22 +3226,22 @@
       "integrity": "sha1-bjufJycMgSsEGsKsSMjPTDmwncs=",
       "dev": true,
       "requires": {
-        "codecov.io": "0.1.6",
-        "coveralls": "2.13.3",
-        "deeper": "2.1.0",
-        "foreground-child": "1.5.6",
-        "glob": "6.0.4",
-        "js-yaml": "3.4.5",
-        "mkdirp": "0.5.1",
-        "nyc": "5.6.0",
-        "only-shallow": "1.2.0",
-        "opener": "1.4.3",
-        "readable-stream": "2.3.3",
-        "signal-exit": "2.1.2",
-        "supports-color": "1.3.1",
-        "tap-mocha-reporter": "0.0.27",
-        "tap-parser": "1.3.2",
-        "tmatch": "1.0.2"
+        "codecov.io": "^0.1.6",
+        "coveralls": "^2.11.2",
+        "deeper": "^2.1.0",
+        "foreground-child": "^1.2.0",
+        "glob": "^6.0.1",
+        "js-yaml": "^3.3.1",
+        "mkdirp": "^0.5.0",
+        "nyc": "^5.1.0",
+        "only-shallow": "^1.0.2",
+        "opener": "^1.4.1",
+        "readable-stream": "^2.0.2",
+        "signal-exit": "^2.0.0",
+        "supports-color": "^1.3.1",
+        "tap-mocha-reporter": "0.0 || 1",
+        "tap-parser": "^1.2.2",
+        "tmatch": "^1.0.2"
       },
       "dependencies": {
         "glob": {
@@ -3250,11 +3250,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "signal-exit": {
@@ -3277,15 +3277,15 @@
       "integrity": "sha1-svcvPh6Lp4DuApGPzes6QNqAGPc=",
       "dev": true,
       "requires": {
-        "color-support": "1.1.3",
-        "debug": "2.6.9",
-        "diff": "1.4.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "js-yaml": "3.4.5",
-        "readable-stream": "1.1.14",
-        "tap-parser": "1.3.2",
-        "unicode-length": "1.0.3"
+        "color-support": "^1.1.0",
+        "debug": "^2.1.3",
+        "diff": "^1.3.2",
+        "escape-string-regexp": "^1.0.3",
+        "glob": "^7.0.5",
+        "js-yaml": "^3.3.1",
+        "readable-stream": "^1.1.13",
+        "tap-parser": "^1.0.4",
+        "unicode-length": "^1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -3294,12 +3294,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "isarray": {
@@ -3316,10 +3316,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3337,10 +3337,10 @@
       "integrity": "sha1-EgxQiciMPIp5PvKIhn3jIeGPjCI=",
       "dev": true,
       "requires": {
-        "events-to-array": "1.1.2",
-        "inherits": "2.0.3",
-        "js-yaml": "3.4.5",
-        "readable-stream": "2.3.3"
+        "events-to-array": "^1.0.1",
+        "inherits": "~2.0.1",
+        "js-yaml": "^3.2.7",
+        "readable-stream": "^2"
       }
     },
     "tape": {
@@ -3349,14 +3349,14 @@
       "integrity": "sha1-Df7scJIn+8yRcKvn8EaWKycUMds=",
       "dev": true,
       "requires": {
-        "deep-equal": "0.1.2",
-        "defined": "0.0.0",
-        "inherits": "2.0.3",
-        "jsonify": "0.0.0",
-        "resumer": "0.0.0",
-        "split": "0.2.10",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
+        "deep-equal": "~0.1.0",
+        "defined": "~0.0.0",
+        "inherits": "~2.0.1",
+        "jsonify": "~0.0.0",
+        "resumer": "~0.0.0",
+        "split": "~0.2.10",
+        "stream-combiner": "~0.0.2",
+        "through": "~2.3.4"
       }
     },
     "tar-fs": {
@@ -3365,10 +3365,10 @@
       "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
       "dev": true,
       "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.5.5"
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
       }
     },
     "tar-stream": {
@@ -3377,10 +3377,10 @@
       "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "dev": true,
       "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "end-of-stream": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "text-table": {
@@ -3407,7 +3407,7 @@
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tryit": {
@@ -3422,7 +3422,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -3438,7 +3438,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typedarray": {
@@ -3454,9 +3454,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -3487,8 +3487,8 @@
       "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1",
-        "strip-ansi": "3.0.1"
+        "punycode": "^1.3.2",
+        "strip-ansi": "^3.0.1"
       }
     },
     "universalify": {
@@ -3518,7 +3518,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -3533,8 +3533,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "verror": {
@@ -3543,9 +3543,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -3562,7 +3562,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wide-align": {
@@ -3571,7 +3571,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "window-size": {
@@ -3593,8 +3593,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -3609,7 +3609,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -3618,9 +3618,9 @@
       "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "slide": "^1.1.5"
       }
     },
     "xml-escape": {
@@ -3654,9 +3654,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     }

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -1,5 +1,6 @@
 var test = require('tap').test;
 var errors = require('../lib/memjs/protocol').errors;
+var memjsBuffer = require('../lib/memjs/buffer');
 var MemJS = require('../');
 
 test('GetSuccessful', function(t) {
@@ -489,7 +490,7 @@ test('IncrementSuccessful', function(t) {
     t.equal(expectedExtras[n], request.extras.toString());
     n += 1;
     process.nextTick(function() {
-      var value = Buffer.alloc(8);
+      var value = memjsBuffer.alloc(8);
       value.writeUInt32BE(request.header.opcode + 1, 4);
       value.writeUInt32BE(0, 0);
       dummyServer.respond({header: {status: 0, opaque: request.header.opaque}, val: value});
@@ -537,7 +538,7 @@ test('DecrementSuccessful', function(t) {
                  request.extras.toString());
     n += 1;
     process.nextTick(function() {
-      var value = Buffer.alloc(8);
+      var value = memjsBuffer.alloc(8);
       value.writeUInt32BE(request.header.opcode, 4);
       value.writeUInt32BE(0, 0);
       dummyServer.respond({header: {status: 0, opaque: request.header.opaque}, val: value});
@@ -566,7 +567,7 @@ test('DecrementSuccessfulWithoutOption', function(t) {
                  request.extras.toString());
     n += 1;
     process.nextTick(function() {
-      var value = Buffer.alloc(8);
+      var value = memjsBuffer.alloc(8);
       value.writeUInt32BE(request.header.opcode, 4);
       value.writeUInt32BE(0, 0);
       dummyServer.respond({header: {status: 0, opaque: request.header.opaque}, val: value});

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -489,7 +489,7 @@ test('IncrementSuccessful', function(t) {
     t.equal(expectedExtras[n], request.extras.toString());
     n += 1;
     process.nextTick(function() {
-      var value = new Buffer(8);
+      var value = Buffer.alloc(8);
       value.writeUInt32BE(request.header.opcode + 1, 4);
       value.writeUInt32BE(0, 0);
       dummyServer.respond({header: {status: 0, opaque: request.header.opaque}, val: value});
@@ -537,7 +537,7 @@ test('DecrementSuccessful', function(t) {
                  request.extras.toString());
     n += 1;
     process.nextTick(function() {
-      var value = new Buffer(8);
+      var value = Buffer.alloc(8);
       value.writeUInt32BE(request.header.opcode, 4);
       value.writeUInt32BE(0, 0);
       dummyServer.respond({header: {status: 0, opaque: request.header.opaque}, val: value});
@@ -566,7 +566,7 @@ test('DecrementSuccessfulWithoutOption', function(t) {
                  request.extras.toString());
     n += 1;
     process.nextTick(function() {
-      var value = new Buffer(8);
+      var value = Buffer.alloc(8);
       value.writeUInt32BE(request.header.opcode, 4);
       value.writeUInt32BE(0, 0);
       dummyServer.respond({header: {status: 0, opaque: request.header.opaque}, val: value});

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -1,5 +1,6 @@
 var test = require('tap').test;
 var utils = require('../lib/memjs/utils');
+var memjsBuffer = require('../lib/memjs/buffer');
 
 test('MergePresereParameter', function(t) {
   var result = utils.merge({}, { retries: 2 });
@@ -25,7 +26,7 @@ test('MergeDontPresereParameterWhenUndefinedOrNull', function(t) {
 test('MakeAmountInitialAndExpiration', function(t) {
   var extras, buf, fixture;
   extras = utils.makeAmountInitialAndExpiration(1, 1, 1);
-  fixture = new Buffer('0000000000000001000000000000000100000001', 'hex');
+  fixture = memjsBuffer.from('0000000000000001000000000000000100000001', 'hex');
   t.equal(20, extras.length);
   t.equal(fixture.toString('hex'), extras.toString('hex'));
   buf = new Buffer(extras);
@@ -33,7 +34,7 @@ test('MakeAmountInitialAndExpiration', function(t) {
   t.equal(fixture.toString('hex'), buf.toString('hex'));
 
   extras = utils.makeAmountInitialAndExpiration(255, 1, 1);
-  fixture = new Buffer('00000000000000ff000000000000000100000001', 'hex');
+  fixture = memjsBuffer.from('00000000000000ff000000000000000100000001', 'hex');
   t.equal(20, extras.length);
   t.equal(fixture.toString('hex'), extras.toString('hex'));
   buf = new Buffer(extras);


### PR DESCRIPTION
Starting in node 10 new Buffer will be deprecated. 
https://nodejs.org/api/buffer.html#buffer_class_buffer

This is a patch use `Buffer.from` and `Buffer.alloc` instead, but to support older versions of node -- backwards compatible methods have been added. 