### PR TITLE
fix: error 'Promise' is not defined

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,9 @@
             "always"
         ]
     },
+    "globals": {
+        "Promise": "readonly"
+    },
     "env": {
         "node": true,
         "browser": true


### PR DESCRIPTION
The eslint fails as `Promise` is not defined on the environment which `ecmaVersion` is not `6`.

```
$ eslint ./lib/memjs

lib/memjs/memjs.js
  105:14  error  'Promise' is not defined  no-undef

✖ 1 problem (1 error, 0 warnings)
```

This PR declares `Promise` as a readonly global variable.