### PR TITLE
fix: .set() method without options

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -183,6 +183,7 @@ Client.prototype.get = function(key, callback) {
 Client.prototype.set = function(key, value, options, callback) {
   if(callback === undefined && typeof options !== 'function') {
     var self = this;
+    if (!options) options = {};
     return promisify(function(callback) { self.set(key, value, options, function(err, success) { callback(err, success); }); });
   }
   var logger = this.options.logger;
@@ -238,6 +239,7 @@ Client.prototype.set = function(key, value, options, callback) {
 Client.prototype.add = function(key, value, options, callback) {
   if(callback === undefined && options !== 'function') {
     var self = this;
+    if (!options) options = {};
     return promisify(function(callback) { self.add(key, value, options, function(err, success) { callback(err, success); }); });
   }
   var logger = this.options.logger;
@@ -296,6 +298,7 @@ Client.prototype.add = function(key, value, options, callback) {
 Client.prototype.replace = function(key, value, options, callback) {
   if(callback === undefined && options !== 'function') {
     var self = this;
+    if (!options) options = {};
     return promisify(function(callback) { self.replace(key, value, options, function(err, success) { callback(err, success); }); });
   }
   var logger = this.options.logger;
@@ -392,6 +395,7 @@ Client.prototype.increment = function(key, amount, options, callback) {
   if(callback === undefined && options !== 'function') {
     var self = this;
     return promisify(function(callback) {
+      if (!options) options = {};
       self.increment(key, amount, options, function(err, success, value) {
         callback(err, {success: success, value: value});
       });

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -136,6 +136,25 @@ test('SetSuccessfulWithoutOption', function(t) {
   });
 });
 
+test('SetPromiseWithoutOption', function(t) {
+  var n = 0;
+  var dummyServer = new MemJS.Server();
+  dummyServer.write = function(requestBuf) {
+    var request = MemJS.Utils.parseMessage(requestBuf);
+    t.equal('hello', request.key.toString());
+    t.equal('world', request.val.toString());
+    n += 1;
+    dummyServer.respond({header: {status: 0, opaque: request.header.opaque}});
+  };
+
+  var client = new MemJS.Client([dummyServer]);
+  return client.set('hello', 'world').then(function(val) {
+    t.equal(true, val);
+    t.equal(1, n, 'Ensure set is called');
+    t.end();
+  });
+});
+
 test('SetWithExpiration', function(t) {
   var n = 0;
   var dummyServer = new MemJS.Server();


### PR DESCRIPTION
The following code fires a `TypeError: Cannot read property 'expires' of undefined`.

```js
const memjs = require('memjs');
const client = memjs.Client.create();
client.set("foo", "bar").catch(console.error);
```

The third argument `options` is not optional for Promise version of `set()`, `add()`, `replace()` and `increment()` methods.
This PR make `options` optional, literally.