### PR TITLE
fix RangeError: The value of "value" is out of range.

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -832,12 +832,10 @@ Client.prototype.perform = function(key, request, seq, callback, retries) {
 
 // Increment the seq value
 Client.prototype.incrSeq = function() {
+  this.seq++;
+
   // Wrap `this.seq` to 32-bits since the field we fit it into is only 32-bits.
-  if (this.seq == 0xffffffff) {
-    this.seq = 0;
-  } else {
-    this.seq++;
-  }
+  this.seq &= 0xffffffff;
 };
 
 exports.Client = Client;


### PR DESCRIPTION
The `Very Large Client Seq` test, which is added at PR #126, fails.
e88faf6e fails while b03bbdd8 passes.

```
$ tap -R spec ./test/client_test.js 

  1) ./test/client_test.js Very Large Client Seq RangeError: The value of "value" is out of range. It must be >= 0 and <= 4294967295. Received 8_589_934_593:
     Error: RangeError: The value of "value" is out of range. It must be >= 0 and <= 4294967295. Received 8_589_934_593
      at checkInt (internal/buffer.js:69:11)
      at writeU_Int32BE (internal/buffer.js:799:3)
      at Buffer.writeUInt32BE (internal/buffer.js:812:10)
      at Object.exports.toBuffer (lib/memjs/header.js:32:13)
      at exports.makeRequestBuffer (lib/memjs/utils.js:23:10)
      at Client.add (lib/memjs/memjs.js:263:17)
      at test/client_test.js:866:10
```

This PR wraps the `this.seq` to 32-bit unsigned integer as it seems it is 32-bit instead of 31-bit.
https://github.com/memcached/memcached/blob/master/doc/protocol.txt