### PR TITLE
avoid calculating hashCode for single server

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -86,12 +86,13 @@ Client.create = function(serversStr, options) {
 Client.prototype.server = function(key) {
   // TODO(alevy): should use consistent hashing and/or allow swapping hashing
   // mechanisms
-  var origIdx = hashCode(key) % this.servers.length;
+  var total = this.servers.length;
+  var origIdx = (total > 1) ? (hashCode(key) % total) : 0;
   var idx = origIdx;
   var serv = this.servers[idx];
   while (serv.wakeupAt &&
       serv.wakeupAt > Date.now()) {
-    idx = (idx + 1) % this.servers.length;
+    idx = (idx + 1) % total;
     if (idx === origIdx) {
       return null;
     }


### PR DESCRIPTION
`hashCode()` function runs every time `perform()` method called. It costs.
It should run only when multiple server endpoints are given.
This PR skip it when the only one server endpoint is given.

| number of servers | BEFORE | AFTER |
|----|----|---|
| single server === 1 | calc `hashCode()` |  **skip** `hashCode()` ✅  |
| multiple servers > 1 | calc `hashCode()` | calc `hashCode()` |

In my case, AWS ElastiCache gives a single server endpoint.