### PR TITLE
feat: allow pluggable HashRing for server lookup

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -11,8 +11,9 @@ var makeAmountInitialAndExpiration = require('./utils').makeAmountInitialAndExpi
 
 // Client initializer takes a list of `Server`s and an `options` dictionary.
 // See `Client.create` for details.
-var Client = function(servers, options) {
+var Client = function(servers, options, serversLookup) {
   this.servers = servers;
+  this.serversLookup = serversLookup;
   this.seq = 0;
   this.options = merge(options || {},
     {failoverTime: 60, retries: 2, retry_delay: 0.2, expires: 0, logger: console});
@@ -73,19 +74,26 @@ Client.create = function(serversStr, options) {
   serversStr = serversStr || process.env.MEMCACHIER_SERVERS ||
                              process.env.MEMCACHE_SERVERS || 'localhost:11211';
   var serverUris = serversStr.split(',');
+  var serversLookup = {};
   var servers = serverUris.map(function(uri) {
     var uriParts = uri.split('@');
     var hostPort = uriParts[uriParts.length - 1].split(':');
     var userPass = (uriParts[uriParts.length - 2] || '').split(':');
+    serversLookup[uri] = server;
     return new Server(hostPort[0], parseInt(hostPort[1] || 11211, 10), userPass[0], userPass[1], options);
   });
-  return new Client(servers, options);
+  return new Client(servers, options, serversLookup);
 };
 
 // Chooses the server to talk to by hashing the given key.
 Client.prototype.server = function(key) {
   // TODO(alevy): should use consistent hashing and/or allow swapping hashing
   // mechanisms
+  // allow use of a pluggable HashRing ie: https://github.com/3rd-Eden/node-hashring
+  if (this.HashRing) {
+    const serverUri = this.HashRing.get(key);
+    return this.serversLookup[serverUri]
+  }
   var total = this.servers.length;
   var origIdx = (total > 1) ? (hashCode(key) % total) : 0;
   var idx = origIdx;


### PR DESCRIPTION
Very small changes for pluggable HashRing ie https://github.com/3rd-Eden/node-hashring

Example:

```js
const memjs = require('memjs');
const HashRing = require('hashring');

const servers = ['server1.memcache.io:1100','server2.memcache.io:1100'];
const hashRing = new HashRing(servers);
const client = memjs.Client.create(servers.join(','));
client.HashRing = hashRing;
```

The HashRing simply needs to expose a "get(key:string)" function and return the server URL. Note that I keep a lookup between server URL and `Server` created by memjs as this is how HashRing implements lookup.