### PR TITLE
Feature: Allows overriding a getServer method for using a hashring

### DIFF
--- a/lib/memjs/memjs.js
+++ b/lib/memjs/memjs.js
@@ -82,12 +82,33 @@ Client.create = function(serversStr, options) {
   return new Client(servers, options);
 };
 
+// An overridable method you can use for determing
+// server selection. Should return the server index
+// in the list of servers on Client#servers.
+// 
+//   Example using node-hashring:
+//   ~~~~
+//   const memjs = require('memjs');
+//   const HashRing = require('node-hashring');
+//   const servers = ['localhost:11211', 'localhost:11212'];
+//   // build a map of server addresses to their index in the server list
+//   const serverMap = {};
+//   servers.forEach((server, index) => serverMap[server] = index);
+//   const client = memjs.Client.create(servers.join(','));
+//   // build the hashring
+//   const hashRing = new HashRing(servers);
+//   // override the getServer method
+//   client.getServer = (key) => serverMap[hashRing.findNode(key)];
+//   ~~~~
+Client.prototype.getServer = function(key) {
+  return hashCode(key) % this.servers.length;
+};
+
 // Chooses the server to talk to by hashing the given key.
 Client.prototype.server = function(key) {
-  // TODO(alevy): should use consistent hashing and/or allow swapping hashing
   // mechanisms
   var total = this.servers.length;
-  var origIdx = (total > 1) ? (hashCode(key) % total) : 0;
+  var origIdx = total > 1 ? this.getServer(key) : 0;
   var idx = origIdx;
   var serv = this.servers[idx];
   while (serv.wakeupAt &&


### PR DESCRIPTION
_Continuing the conversation from #158._

This is a very simple addition to the codebase that will make it easy to hook in a consistent hashing ring.

I'd also like to suggest using [node-hashring](https://www.npmjs.com/package/node-hashring) for performance instead of the 3rd-eden HashRing. Most notably, 3rd-Eden's implementation uses a 128-bit MD5 and then reduces it to a 32-bit uint and **node-hashring** uses the 32-bit MurmurHash algorithm which offers tremendous performance gains.

### Usage

```js
const memjs = require('memjs');
const HashRing = require('node-hashring');
const servers = ['localhost:11211', 'localhost:11212'];
// build a map of server addresses to their index in the server list
const serverMap = {};
servers.forEach((server, index) => serverMap[server] = index);
const client = memjs.Client.create(servers.join(','));
// build the hashring
const hashRing = new HashRing(servers);
// override the getServer method
client.getServer = (key) => serverMap[hashRing.findNode(key)];

client.set('hello', 'world', {expires: 600}, function(err) {
  console.error(err);
});

client.get('hello', function(err, val) {
  if (err) {
    console.error(err);
  }
  console.log(val.toString());
});
```

