### PR TITLE
Listen for more socket failure events

### DIFF
--- a/lib/memjs/server.js
+++ b/lib/memjs/server.js
@@ -149,7 +149,7 @@ Server.prototype.sock = function(sasl, go) {
     });
 
     // setup error handler
-    self._socket.on('error', function(error) {
+    var socketErrorListener = function(error) {
       self.connected = false;
       if (self.timeoutSet) {
         self._socket.setTimeout(0);
@@ -157,7 +157,10 @@ Server.prototype.sock = function(sasl, go) {
       }
       self._socket = undefined;
       self.error(error);
-    });
+    };
+    self._socket.on('error', socketErrorListener);
+    self._socket.on('close', socketErrorListener);
+    self._socket.on('disconnect', socketErrorListener);
 
     // setup connection timeout handler
     self.timeoutSet = true;

--- a/lib/memjs/server.js
+++ b/lib/memjs/server.js
@@ -149,7 +149,7 @@ Server.prototype.sock = function(sasl, go) {
     });
 
     // setup error handler
-    var socketErrorListener = function(error) {
+    self._socket.on('close', function(error) {
       self.connected = false;
       if (self.timeoutSet) {
         self._socket.setTimeout(0);
@@ -157,10 +157,7 @@ Server.prototype.sock = function(sasl, go) {
       }
       self._socket = undefined;
       self.error(error);
-    };
-    self._socket.on('error', socketErrorListener);
-    self._socket.on('close', socketErrorListener);
-    self._socket.on('disconnect', socketErrorListener);
+    });
 
     // setup connection timeout handler
     self.timeoutSet = true;


### PR DESCRIPTION
Fixes #162. 

I'm not sure if there's a better way to solve the problem, but listening for the `close` event seems to deal with the problem for me. If the host disappears suddenly, `error` doesn't seem to be called. I added `disconnect` just in case, but perhaps this is unnecessary.