### PR TITLE
Clear socket on MemJS.Server when connection is closed

### DIFF
--- a/lib/memjs/server.js
+++ b/lib/memjs/server.js
@@ -150,12 +150,6 @@ Server.prototype.sock = function(sasl, go) {
 
     // setup error handler
     self._socket.on('error', function(error) {
-      self.connected = false;
-      if (self.timeoutSet) {
-        self._socket.setTimeout(0);
-        self.timeoutSet = false;
-      }
-      self._socket = undefined;
       self.error(error);
     });
 

--- a/lib/memjs/server.js
+++ b/lib/memjs/server.js
@@ -159,6 +159,15 @@ Server.prototype.sock = function(sasl, go) {
       self.error(error);
     });
 
+    self._socket.on('close', function() {
+      self.connected = false;
+      if (self.timeoutSet) {
+        self._socket.setTimeout(0);
+        self.timeoutSet = false;
+      }
+      self._socket = undefined;
+    });
+
     // setup connection timeout handler
     self.timeoutSet = true;
     self._socket.setTimeout(self.options.conntimeout * 1000, function() {


### PR DESCRIPTION
Some services I'm working on have been facing issues with MemJS on Node 15+. This seems to be related to the fact that `net.Socket` does not emit "error" when `memjs` attempts to write into an already closed socket. 

This PR adds `socket.on('close')` listener to clear up socket on `MemJS.Server`. After the change, `memjs` will automatically re-establish the connection on next read / write to memcached even on Node 15+.

Unfortunately, I could not figure how to reproduce the issue in `memjs` test suite as I needed to bring in a real memcached server with me. Here is a script demonstrating the bug we are facing:

```js
// Insert into ./test/e2e_test.js
// Run using `node ./test/e2e_test.js`

var MemJS = require("../");

console.log("Initialising Memcached connection");
// Create a real server as the behaviour is not reproducible without making a real connection to the server
var server = new MemJS.Server("localhost", "11211");
var client = new MemJS.Client([server]);

console.log("Write initial value with a live connection");
client.set("foo", "bar").then(function () {
  console.log("Close connection (can happen for a myriad of other reasons too");
  server.close();

  // Waiting is required for some reason to
  // reproduce the failure case we are seeing on Node 15+
  // Something to do with the event loop maybe?
  console.log("Waiting for 1s...");
  setTimeout(function () {
    client
      .set("foo", "baz")
      .then(function (success) {
        // This will not run without the patch applied on Node 15+
        // "Error: This socket has been ended by the other party" will be logged on Node <= 14
        // but write will succeed anyway (new socket is created)
        console.log("Succesfully updated:", success);
        client.quit();
      })
      .catch(function (err) {
        // We will never reach this catch clause
        console.error(err);
      });
  }, 1000);
});

```